### PR TITLE
Spine validation

### DIFF
--- a/docs/Data/Generic.md
+++ b/docs/Data/Generic.md
@@ -75,6 +75,14 @@ instance genericMaybe :: (Generic a) => Generic (Maybe a)
 instance genericEither :: (Generic a, Generic b) => Generic (Either a b)
 ```
 
+#### `isValidSpine`
+
+``` purescript
+isValidSpine :: GenericSignature -> GenericSpine -> Boolean
+```
+
+Checks that the spine follows the structure defined by the signature
+
 #### `gShow`
 
 ``` purescript


### PR DESCRIPTION
Adds a function `isValidSpine` which takes GenericSignature and
GenericSpine and checks that the spine conforms to the signature.