### PR TITLE
Use Type.Proxy.Proxy

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "purescript-arrays": "^0.4.2",
     "purescript-either": "^0.2.1",
+    "purescript-proxy": "^0.1.0",
     "purescript-strings": "^0.7.0"
   },
   "devDependencies": {

--- a/src/Data/Generic.purs
+++ b/src/Data/Generic.purs
@@ -3,7 +3,7 @@ module Data.Generic
    GenericSpine(..),
    GenericSignature(..),
    isValidSpine,
-   Proxy(..),
+   module Type.Proxy,
    anyProxy,
    gShow,
    gEq,
@@ -19,6 +19,7 @@ import Data.Traversable (traverse)
 import Data.Foldable (all, and, find)
 import Data.Array (null, length, sortBy, zipWith)
 import Data.String (joinWith)
+import Type.Proxy (Proxy(..))
 
 -- | A GenericSpine is a universal represntation of an arbitrary data structure (that does not contain function arrows).
 data GenericSpine = SProd String (Array (Unit -> GenericSpine))
@@ -39,9 +40,6 @@ data GenericSignature = SigProd (Array {sigConstructor :: String, sigValues :: A
                       | SigString 
                       | SigChar
                       | SigArray (Unit -> GenericSignature)
-
--- | A proxy is a simple placeholder data type to allow us to pass type-level data at runtime.
-data Proxy a = Proxy
 
 anyProxy :: forall a. Proxy a
 anyProxy = Proxy


### PR DESCRIPTION
This pull request fixes #18. It adds a dependency on purescript-proxy and uses `Type.Proxy.Proxy` instead of defining `Data.Generic.Proxy`. I also made `Data.Generic` re-export `Proxy` to minimize breakage. 